### PR TITLE
improve textview and multi-column treeview support in dt_ui_scroll_wrap

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1454,65 +1454,65 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/tagging/heightattachedwindow</name>
-    <type min="15" max="1000">int</type>
+    <type>int</type>
     <default>100</default>
     <shortdescription>height of the tagging attached view</shortdescription>
     <longdescription>maximum height the tagging attached view will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/tagging/heightdictionarywindow</name>
-    <type min="15" max="1000">int</type>
+    <type>int</type>
     <default>200</default>
     <shortdescription>height of the tagging dictionary view</shortdescription>
     <longdescription>maximum height the tagging dictionary view will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/creator_text_height</name>
-    <type min="15" max="1000">int</type>
-    <default>15</default>
-    <shortdescription>height of the metadata textview</shortdescription>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>height of the metadata creator field</shortdescription>
     <longdescription>maximum height the metadata textview will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/publisher_text_height</name>
-    <type min="15" max="1000">int</type>
-    <default>15</default>
-    <shortdescription>height of the metadata textview</shortdescription>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>height of the metadata publisher field</shortdescription>
     <longdescription>maximum height the metadata textview will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/title_text_height</name>
-    <type min="15" max="1000">int</type>
-    <default>15</default>
-    <shortdescription>height of the metadata textview</shortdescription>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>height of the metadata title field</shortdescription>
     <longdescription>maximum height the metadata textview will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/description_text_height</name>
-    <type min="15" max="1000">int</type>
-    <default>15</default>
-    <shortdescription>height of the metadata textview</shortdescription>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>height of the metadata description field</shortdescription>
     <longdescription>maximum height the metadata textview will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/rights_text_height</name>
-    <type min="15" max="1000">int</type>
-    <default>15</default>
-    <shortdescription>height of the metadata textview</shortdescription>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>height of the metadata rights field</shortdescription>
     <longdescription>maximum height the metadata textview will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/notes_text_height</name>
-    <type min="15" max="1000">int</type>
-    <default>15</default>
-    <shortdescription>height of the metadata textview</shortdescription>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>height of the metadata notes field</shortdescription>
     <longdescription>maximum height the metadata textview will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/metadata/version name_text_height</name>
-    <type min="15" max="1000">int</type>
-    <default>15</default>
-    <shortdescription>height of the metadata textview</shortdescription>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>height of the metadata version name field</shortdescription>
     <longdescription>maximum height the metadata textview will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig prefs="security">

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -332,14 +332,7 @@ static void _update_layout(dt_lib_module_t *self)
     {
       for(int j = 0; j < 2; j++)
       {
-        gtk_widget_hide(gtk_grid_get_child_at(d->metadata_grid,j,i));
-      }
-    }
-    else
-    {
-      for(int j = 0; j < 2; j++)
-      {
-        gtk_widget_show(gtk_grid_get_child_at(d->metadata_grid,j,i));
+        gtk_widget_set_no_show_all(gtk_grid_get_child_at(d->metadata_grid,j,i), TRUE);
       }
     }
     g_free(setting);
@@ -599,12 +592,6 @@ static gboolean _click_on_textview(GtkWidget *textview, GdkEventButton *event, d
   return TRUE;
 }
 
-void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height,
-                        int32_t pointerx, int32_t pointery)
-{
-  _update_layout(self);
-}
-
 void gui_init(dt_lib_module_t *self)
 {
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)calloc(1, sizeof(dt_lib_metadata_t));
@@ -623,7 +610,6 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(self->widget, "metadata_editor.html#metadata_editor_usage");
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(10));
-  gint line_height = 0;
 
   for(int i = 0; i < DT_METADATA_NUMBER; i++)
   {
@@ -636,23 +622,13 @@ void gui_init(dt_lib_module_t *self)
               "\nin that case, right-click gives the possibility to choose one of them."
               "\npress escape to exit the popup window"));
 
-    GtkTextBuffer *buffer = gtk_text_buffer_new(NULL);
-    gtk_text_buffer_create_tag (buffer, "italic", "style", PANGO_STYLE_ITALIC, NULL);
-    GtkWidget *textview = gtk_text_view_new_with_buffer(buffer);
+    GtkWidget *textview = gtk_text_view_new();
+    gtk_text_buffer_create_tag (gtk_text_view_get_buffer(GTK_TEXT_VIEW(textview)), "italic", "style", PANGO_STYLE_ITALIC, NULL);
 
     const char *name = (char *)dt_metadata_get_name_by_display_order(i);
     d->setting_name[i] = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_text_height", name);
 
-    if(!line_height)
-    {
-      PangoLayout *cell = gtk_widget_create_pango_layout(GTK_WIDGET(textview), "X");
-      pango_layout_get_size(cell, NULL, &line_height);
-      g_object_unref(cell);
-      line_height /= PANGO_SCALE;
-    }
-
-    GtkWidget *swindow = dt_ui_scroll_wrap(GTK_WIDGET(textview), 5 * line_height,
-                                           d->setting_name[i]);
+    GtkWidget *swindow = dt_ui_scroll_wrap(GTK_WIDGET(textview), 100, d->setting_name[i]);
 
     gtk_grid_attach(grid, swindow, 1, i, 1, 1);
     gtk_widget_set_hexpand(swindow, TRUE);
@@ -669,10 +645,6 @@ void gui_init(dt_lib_module_t *self)
     d->textview[i] = GTK_TEXT_VIEW(textview);
     gtk_widget_set_hexpand(textview, TRUE);
     gtk_widget_set_vexpand(textview, TRUE);
-
-    // doesn't work. Workaround => gui_post_expose
-    // gtk_widget_set_no_show_all(GTK_WIDGET(label), TRUE);
-    // gtk_widget_set_no_show_all(GTK_WIDGET(textview), TRUE);
   }
 
   d->init_layout = FALSE;
@@ -707,6 +679,7 @@ void gui_init(dt_lib_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
                             G_CALLBACK(_collection_updated_callback), self);
   _update(self);
+  _update_layout(self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)


### PR DESCRIPTION
This uses the line height of the text view to resize in steps of whole lines.

It also fixes the same functionality for treeviews that have multiple columns with non-identical heights. This was necessary for the tagging module.

I've added a (very!) simple toast (at top of screen) to show current max (in number of lines). So you can see it changing even if not directly affecting current size.

Also fixes #7120 